### PR TITLE
feat: add pagination example (without prefetching)

### DIFF
--- a/packages/playground/src/app/infinite-query-page/projects.service.ts
+++ b/packages/playground/src/app/infinite-query-page/projects.service.ts
@@ -1,10 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import { InfiniteQueryProvider } from '@ngneat/ng-query';
 import { Observable } from 'rxjs';
-interface Project {
-  id: number;
-  name: string;
-}
+import { Project } from '../types/project';
 
 export interface Projects {
   data: Project[];

--- a/packages/playground/src/app/pagination-page/pagination-page.component.ts
+++ b/packages/playground/src/app/pagination-page/pagination-page.component.ts
@@ -1,16 +1,69 @@
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { SubscribeModule } from '@ngneat/subscribe';
+import { PaginatedProject } from '../types/project';
+import { ProjectsService } from './projects.service';
 
 @Component({
   selector: 'ng-query-pagination-page',
   standalone: true,
-  imports: [CommonModule],
-  template: ` <p>pagination-page works!</p> `,
-  styles: [],
+  imports: [CommonModule, SubscribeModule],
+  template: `
+    <p>
+      In this example, each page of data remains visible as the next page is
+      fetched. The buttons and capability to proceed to the next page are also
+      supressed until the next page cursor is known. Each page is cached as a
+      normal query too, so when going to previous pages, you'll see them
+      instantaneously while they are also refetched invisibly in the background.
+    </p>
+    <div *subscribe="projects$ as projects">
+      <ng-container [ngSwitch]="projects.status">
+        <div *ngSwitchCase="'loading'">Loading...</div>
+        <div *ngSwitchCase="'error'">
+          An error has occurred: {{ projects.error }}
+        </div>
+        <ng-container *ngSwitchDefault>
+          <div *ngFor="let project of projects.data?.projects">
+            <p>{{ project.name }}</p>
+          </div>
+        </ng-container>
+      </ng-container>
+      <div>Current Page: {{ page + 1 }}</div>
+      <button
+        class="btn btn-outline-primary mr-2"
+        (click)="previousPage()"
+        [disabled]="page === 0"
+      >
+        Previous Page
+      </button>
+      <button
+        class="btn btn-outline-primary"
+        (click)="nextPage(projects.data)"
+        [disabled]="projects.isPreviousData || !projects.data?.hasMore"
+      >
+        Next Page
+      </button>
+      <span *ngIf="projects.isFetching"> Loading...</span>
+    </div>
+  `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class PaginationPageComponent implements OnInit {
-  constructor() {}
+export class PaginationPageComponent {
+  page = 0;
+  projectsService = inject(ProjectsService);
+  projects$ = this.projectsService.getProjects(this.page);
 
-  ngOnInit(): void {}
+  triggerFetch() {
+    this.projects$ = this.projectsService.getProjects(this.page);
+  }
+
+  previousPage() {
+    this.page = Math.max(0, this.page - 1);
+    this.triggerFetch();
+  }
+
+  nextPage(data: PaginatedProject | undefined) {
+    this.page = data?.hasMore ? this.page + 1 : this.page;
+    this.triggerFetch();
+  }
 }

--- a/packages/playground/src/app/pagination-page/projects.service.ts
+++ b/packages/playground/src/app/pagination-page/projects.service.ts
@@ -1,0 +1,41 @@
+import { inject, Injectable } from '@angular/core';
+import { QueryProvider } from '@ngneat/ng-query';
+import { Observable } from 'rxjs';
+import { PaginatedProject } from '../types/project';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ProjectsService {
+  private useQuery = inject(QueryProvider);
+
+  getProjects(page: number) {
+    return this.useQuery(['projects', page], () => getProjects(page), {
+      keepPreviousData: true,
+      staleTime: 5000,
+    });
+  }
+}
+
+const PAGE_SIZE = 10;
+function getProjects(page: number) {
+  return new Observable<PaginatedProject>((observer) => {
+    const projects = Array(PAGE_SIZE)
+      .fill(0)
+      .map((_, i) => {
+        const id = page * PAGE_SIZE + (i + 1);
+        return {
+          name: 'Project ' + id,
+          id,
+        };
+      });
+
+    setTimeout(() => {
+      observer.next({
+        projects,
+        hasMore: page < 9,
+      });
+      observer.complete();
+    }, 1000);
+  });
+}

--- a/packages/playground/src/app/simple-page/simple-page.component.ts
+++ b/packages/playground/src/app/simple-page/simple-page.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { SubscribeModule } from '@ngneat/subscribe';
 import { GithubApiService } from '../github.service';
 
@@ -24,7 +24,6 @@ import { GithubApiService } from '../github.service';
   `,
 })
 export class SimplePageComponent {
-  constructor(private githubApiService: GithubApiService) {}
-
+  githubApiService = inject(GithubApiService)
   repo$ = this.githubApiService.getRepository('ngneat/ng-query');
 }

--- a/packages/playground/src/app/types/project.ts
+++ b/packages/playground/src/app/types/project.ts
@@ -1,0 +1,9 @@
+export interface Project {
+  id: number;
+  name: string;
+}
+
+export interface PaginatedProject {
+  projects: Project[];
+  hasMore: boolean;
+}


### PR DESCRIPTION
## Pagination example

This is to bring the [pagination example](https://tanstack.com/query/v4/docs/examples/react/pagination) from query-v4 docs into #4. 

However, it hasn't yet had the prefetching functionality.

https://user-images.githubusercontent.com/6767322/195976899-572911f9-ba77-4e7d-86ca-c888659236a6.mp4


## Preloading next page

What I have in mind for the prefetching is to bake this code into the ProjectsService and trigger them manually on component init or on the next page

```ts
export class ProjectsService {
  private queryClient = inject(QueryClient);

  preFetchNextPage(page: number, data: PaginatedProject | undefined) {
    if (data?.hasMore) {
      this.queryClient.prefetchQuery(['projects', page + 1], () =>
        getProjects(page + 1)
      );
    }
  }
}
```

```diff
export class PaginationPageComponent {
  triggerFetch(data?: PaginatedProject) {
    this.projects$ = this.projectsService.getProjects(this.page);
+    this.projectsService.preFetchNextPage(this.page, data);
  }

  nextPage(data: PaginatedProject | undefined) {
    this.page = data?.hasMore ? this.page + 1 : this.page;
+    this.triggerFetch(data);
  }
}
```