### PR TITLE
Use node 16 for setup-node (#33)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Cache node modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:
@@ -24,9 +22,9 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/query/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
- [x] CI related changes
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #33 

## What is the new behavior?

This PR update 
- setup-node to use node 16
- actions/cache, actions/checkout and actions/setup-node to latest v3.
- Remove the fail-fast on strategy because strategy is required a matrix key.

![Screenshot 2022-10-19 at 9 46 22 AM](https://user-images.githubusercontent.com/6767322/196579958-8f9b2f03-2dfb-477a-9976-ef4a23948112.jpg)

✅ Tested on my repo and it went well. 

https://github.com/trungk18/ng-query/actions/runs/3278222280/jobs/5396376445

![Monosnap fix(ci) use node 16 for setup-node · trungk18ng-query@9063cf9 2022-10-19 09-50-25](https://user-images.githubusercontent.com/6767322/196579825-875a1eb6-5637-4b33-a5d5-eb617def8def.jpg)


