### PR TITLE
feat(devtools): 🔥 add lazy production devtools

### DIFF
--- a/devtools/README.md
+++ b/devtools/README.md
@@ -15,4 +15,19 @@ bootstrapApplication(AppComponent, {
 });
 ```
 
-See all the avilable options [here](https://tanstack.com/query/v5/docs/react/devtools#options).
+See all the available options [here](https://tanstack.com/query/v5/docs/react/devtools#options).
+
+If you would like to lazy-load it in production - use `provideLazyQueryDevTools()`.
+
+```ts
+export const appConfig: ApplicationConfig = {
+  providers: [
+    environment.production
+      ? provideLazyQueryDevTools(options)
+      : provideQueryDevTools(options),
+  ],
+};
+```
+
+This will define a global window function `toggleDevtools()` which will lazy-load and mount the devtools.
+See also [Devtools in production](https://tanstack.com/query/v4/docs/react/devtools#devtools-in-production).

--- a/devtools/src/index.ts
+++ b/devtools/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  APP_INITIALIZER,
   DestroyRef,
   ENVIRONMENT_INITIALIZER,
   inject,
@@ -21,6 +22,29 @@ export function provideQueryDevTools(
         import('./lib/devtools/devtools').then((m) => {
           m.queryDevtools({ queryClient, destroyRef, ...devToolOptions });
         });
+      },
+    },
+  ]);
+}
+
+export function provideLazyQueryDevTools(
+  devToolOptions: Partial<Omit<TanstackQueryDevtoolsConfig, 'client'>> = {},
+  triggerFunction: string = 'toggleDevtools',
+) {
+  return makeEnvironmentProviders([
+    {
+      provide: APP_INITIALIZER,
+      multi: true,
+      useFactory() {
+        const queryClient = injectQueryClient();
+        const destroyRef = inject(DestroyRef);
+        return () => {
+          (window as any)[triggerFunction] = () => {
+            import('./lib/devtools/devtools').then((m) => {
+              m.queryDevtools({ queryClient, destroyRef, ...devToolOptions });
+            });
+          };
+        };
       },
     },
   ]);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/query/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

See discussion https://github.com/ngneat/query/discussions/148

Devtools are currently either hard on or off with no ability to lazy-load them in a production build.

## What is the new behavior?

This PR adds a new `provideLazyQueryDevTools()` which will define a global window function that lazy loads and activates devtools, allowing them to be used in production by opening the developer console.

Here is an example of a prod build app showing the devtools being loaded via the console (and the lazy-loaded chunks coming in):

https://github.com/ngneat/query/assets/9100419/74362281-e3ad-4ba9-a143-695dfb8b9e38



## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

[Further reading](https://tanstack.com/query/v4/docs/react/devtools#devtools-in-production)