### PR TITLE
fix(query): Add export to _CreateBaseQueryOptions type

### DIFF
--- a/query/src/lib/base-query.ts
+++ b/query/src/lib/base-query.ts
@@ -25,7 +25,7 @@ export interface Options {
   injector?: Injector;
 }
 
-interface _CreateBaseQueryOptions<
+export interface _CreateBaseQueryOptions<
   TQueryFnData = unknown,
   TError = DefaultError,
   TData = TQueryFnData,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/query/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

I'm migrating from v1 to v2 and encountered this error: 
`Return type of public method from exported class has or is using name '_CreateBaseQueryOptions' from external module "node_modules/@ngneat/query/lib/base-query" but cannot be named. ts(4053)`
Typescript can't name the return type of 'queryOptions' function in a public class method.

Here is a code example:

```ts
@Injectable({ providedIn: 'root' })
export class ExampleClientService {
    private httpClient = inject(HttpClient);

    queryUser(id: string) {
//  ^? error: Return type of public method from exported class has or is using name '_CreateBaseQueryOptions' from external module "node_modules/@ngneat/query/lib/base-query" but cannot be named.ts(4053)
        return queryOptions({
            queryKey: ['USER', id] as const,
            queryFn: () => {
                return this.httpClient.get(`/user/${id}`);
            },
        });
    }
}
```

Issue Number: N/A

## What is the new behavior?
No more typescript errors when using "queryOptions" function return type in a public class method.
Adding export to the `_CreateBaseQueryOptions` interface fixes the typescript error.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
