### PR TITLE
feat(signals): Add refetch functionality to intersected results

### DIFF
--- a/query/src/lib/operators.ts
+++ b/query/src/lib/operators.ts
@@ -148,6 +148,7 @@ export function intersectResults$<
   return map((values) => {
     const isArray = Array.isArray(values);
     const toArray = isArray ? values : Object.values(values);
+    const refetch = () => Promise.all(toArray.map(v => v.refetch()));
 
     const mappedResult = {
       all: values,
@@ -158,6 +159,7 @@ export function intersectResults$<
       isFetching: toArray.some((v) => v.isFetching),
       error: toArray.find((v) => v.isError)?.error,
       data: undefined,
+      refetch,
     } as unknown as QueryObserverResult<R> & { all: T };
 
     if (mappedResult.isSuccess) {

--- a/query/src/lib/signals.ts
+++ b/query/src/lib/signals.ts
@@ -59,10 +59,11 @@ export function intersectResults<
   signals: T,
   mapFn: (values: UnifiedTypes<T>) => R,
 ): Signal<QueryObserverResult<R> & { all: T }> {
-  return computed(() => {
-    const isArray = Array.isArray(signals);
-    const toArray = isArray ? signals : Object.values(signals);
+  const isArray = Array.isArray(signals);
+  const toArray = isArray ? signals : Object.values(signals);
+  const refetch = () => Promise.all(toArray.map(v => v().refetch()));
 
+  return computed(() => {
     const mappedResult = {
       all: signals,
       isSuccess: toArray.every((v) => v().isSuccess),
@@ -72,7 +73,7 @@ export function intersectResults<
       isFetching: toArray.some((v) => v().isFetching),
       error: toArray.find((v) => v().isError)?.error,
       data: undefined,
-      refetch: () => Promise.all(toArray.map(v => v().refetch())),
+      refetch,
     } as unknown as QueryObserverResult<R> & { all: T };
 
     if (mappedResult.isSuccess) {

--- a/query/src/lib/signals.ts
+++ b/query/src/lib/signals.ts
@@ -72,6 +72,7 @@ export function intersectResults<
       isFetching: toArray.some((v) => v().isFetching),
       error: toArray.find((v) => v().isError)?.error,
       data: undefined,
+      refetch: () => Promise.all(toArray.map(v => v().refetch())),
     } as unknown as QueryObserverResult<R> & { all: T };
 
     if (mappedResult.isSuccess) {


### PR DESCRIPTION
This change ensures that all intersected queries are refetched when "refetch" is called on the combined result.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/query/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Intersected results cannot be refetched via the refetch callback (it is undefined).

Issue Number: #162 

A refetch callback is added that refetches all intersected queries when called.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No