### PR TITLE
Allow intersecting stale results

### DIFF
--- a/query/src/lib/signals.ts
+++ b/query/src/lib/signals.ts
@@ -27,7 +27,7 @@ type UnifiedTypes<T> = T extends Array<Signal<QueryObserverBaseResult<any>>>
  *  This function is used to merge multiple signal queries into one.
  *  It will return a new base query result that will merge the results of all the queries.
  *  Note that it should be used inside injection context.
- *  If you pass the 'intersectStaleData' flag, it will also intersect unsuccessful result if data for all queries is present.
+ *  If you pass the 'intersectStaleData' flag, it will also intersect unsuccessful result in case data for all queries is present.
  *
  * @example
  *
@@ -37,7 +37,6 @@ type UnifiedTypes<T> = T extends Array<Signal<QueryObserverBaseResult<any>>>
  * }, ({ todos, posts }) => {
  *   return todos + posts;
  * });
- *
  *
  * @example
  *
@@ -50,7 +49,6 @@ type UnifiedTypes<T> = T extends Array<Signal<QueryObserverBaseResult<any>>>
  *    return todoOne.title + todoTwo.title;
  *  }
  * );
- *
  *
  * @example
  *
@@ -79,7 +77,7 @@ export function intersectResults<
     : () => Object.entries(signals).reduce((acc, [key, value]) => {
         acc[key as keyof UnifiedTypes<T>] = value().data;
         return acc;
-      }, {} as UnifiedTypes<T>)
+      }, {} as UnifiedTypes<T>);
 
   return computed(() => {
     const mappedResult = {

--- a/query/src/lib/signals.ts
+++ b/query/src/lib/signals.ts
@@ -26,7 +26,8 @@ type UnifiedTypes<T> = T extends Array<Signal<QueryObserverBaseResult<any>>>
  *
  *  This function is used to merge multiple signal queries into one.
  *  It will return a new base query result that will merge the results of all the queries.
- *  Note that it should be used inside injection context
+ *  Note that it should be used inside injection context.
+ *  If you pass the 'intersectStaleData' flag, it will also intersect unsuccessful result if data for all queries is present.
  *
  * @example
  *
@@ -35,7 +36,7 @@ type UnifiedTypes<T> = T extends Array<Signal<QueryObserverBaseResult<any>>>
  *   posts: posts.result$,
  * }, ({ todos, posts }) => {
  *   return todos + posts;
- * })
+ * });
  *
  *
  * @example
@@ -49,6 +50,16 @@ type UnifiedTypes<T> = T extends Array<Signal<QueryObserverBaseResult<any>>>
  *    return todoOne.title + todoTwo.title;
  *  }
  * );
+ *
+ *
+ * @example
+ *
+ * const query = intersetResults({
+ *   todos: todos.result$,
+ *   posts: posts.result$,
+ * }, ({ todos, posts }) => {
+ *   return todos + posts;
+ * }, { intersectStaleData: true });
  */
 export function intersectResults<
   T extends
@@ -58,10 +69,17 @@ export function intersectResults<
 >(
   signals: T,
   mapFn: (values: UnifiedTypes<T>) => R,
+  options?: { intersectStaleData: boolean }
 ): Signal<QueryObserverResult<R> & { all: T }> {
   const isArray = Array.isArray(signals);
   const toArray = isArray ? signals : Object.values(signals);
   const refetch = () => Promise.all(toArray.map(v => v().refetch()));
+  const intersectData = isArray
+    ? () => toArray.map((r) => r().data) as UnifiedTypes<T>
+    : () => Object.entries(signals).reduce((acc, [key, value]) => {
+        acc[key as keyof UnifiedTypes<T>] = value().data;
+        return acc;
+      }, {} as UnifiedTypes<T>)
 
   return computed(() => {
     const mappedResult = {
@@ -76,20 +94,8 @@ export function intersectResults<
       refetch,
     } as unknown as QueryObserverResult<R> & { all: T };
 
-    if (mappedResult.isSuccess) {
-      if (isArray) {
-        mappedResult.data = mapFn(
-          toArray.map((r) => r().data) as UnifiedTypes<T>,
-        );
-      } else {
-        const data = Object.entries(signals).reduce((acc, [key, value]) => {
-          acc[key as keyof UnifiedTypes<T>] = value().data;
-
-          return acc;
-        }, {} as UnifiedTypes<T>);
-
-        mappedResult.data = mapFn(data);
-      }
+    if (mappedResult.isSuccess || (options?.intersectStaleData && toArray.every((v) => !!v().data))) {
+      mappedResult.data = mapFn(intersectData());
     }
 
     return mappedResult;


### PR DESCRIPTION
This change allows intersecting not only current, but also stale data from multiple queries.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/query/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

At the moment, the data is only intersected if all queries are successful.

Issue Number: N/A

## What is the new behavior?

If an option is passed, data will also returned if all queries contain data (stale or current).

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
