### PR TITLE
docs(query): Fix docs for RxJS Operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,27 +394,27 @@ export class TodosPageComponent {
 
 ### filterSuccessResult
 
-The `filterSuccess` operator is useful when you want to filter only successful results:
+The `filterSuccessResult` operator is useful when you want to filter only successful results:
 
-`todosService.getTodos().result$.pipe(filterSuccess())`
+`todosService.getTodos().result$.pipe(filterSuccessResult())`
 
 ### filterErrorResult
 
-The `filterError` operator is useful when you want to filter only error results:
+The `filterErrorResult` operator is useful when you want to filter only error results:
 
-`todosService.getTodos().result$.pipe(filterError())`
+`todosService.getTodos().result$.pipe(filterErrorResult())`
 
 ### tapSuccessResult
 
-The `tapSuccess` operator is useful when you want to run a side effect only when the result is successful:
+The `tapSuccessResult` operator is useful when you want to run a side effect only when the result is successful:
 
-`todosService.getTodos().result$.pipe(tapSuccess(console.log))`
+`todosService.getTodos().result$.pipe(tapSuccessResult(console.log))`
 
 ### tapErrorResult
 
-The `tapErrorResult` operator is useful when you want to run a side effect only when the result is successful:
+The `tapErrorResult` operator is useful when you want to run a side effect only when the result is erroring:
 
-`todosService.getTodos().result$.pipe(tapError(console.log))`
+`todosService.getTodos().result$.pipe(tapErrorResult(console.log))`
 
 ### mapResultData
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/query/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
In RxJS operators session of README.md 
- There are references of operators that do not exist.
- there is a typo for `tapErrorResult`:  `...effect only when the result is successful`

Issue Number: N/A

## What is the new behavior?
- Correctly referencing operators.
- Fixed the typo for `tapErrorResult`:  `...effect only when the result is erroring`

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
N/A