### PR TITLE
feat(query-client): support for passing custom  QueryClient instance …

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,25 @@ export class TodosService {
   #queryClient = injectQueryClient();
 }
 ```
+or provide `QueryClient` [instance](https://tanstack.com/query/v5/docs/reference/QueryClient) manually
 
-> The function should run inside an injection context
+```ts
+import { provideQueryClient } from '@ngneat/query';
+import { QueryClient } from '@tanstack/query-core';
+
+provideQueryClient(() =>  new QueryClient())
+```
+
+and then use with
+
+```ts
+import { injectQueryClient } from '@ngneat/query';
+
+  ...
+  #queryClient = injectQueryClient();
+```
+
+> Functions should run inside an injection context
 
 ### Query
 

--- a/query/src/lib/query-client.ts
+++ b/query/src/lib/query-client.ts
@@ -60,10 +60,13 @@ const QueryClientService = new InjectionToken<QueryClient>(
 );
 
 /** @public */
-export function provideQueryClient(queryClient: QueryClient): Provider {
+export function provideQueryClient(queryClientOrFactory: _QueryClient | (() => _QueryClient)): Provider {
   return {
     provide: QueryClientToken,
-    useValue: queryClient,
+    useFactory:
+      typeof queryClientOrFactory === 'function'
+        ? queryClientOrFactory
+        : () => queryClientOrFactory,
   };
 }
 

--- a/query/src/tests/query-client.spec.ts
+++ b/query/src/tests/query-client.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed, fakeAsync, flush, tick } from '@angular/core/testing';
-import { InfiniteData } from '@tanstack/query-core';
+import { InfiniteData, QueryClient as _QueryClient } from '@tanstack/query-core';
 import { expectTypeOf } from 'expect-type';
-import { QueryClient, injectQueryClient } from '../lib/query-client';
+import { QueryClient, injectQueryClient, provideQueryClient } from '../lib/query-client';
 import {
   Posts,
   PostsService,
@@ -135,3 +135,39 @@ describe('QueryClient', () => {
     >();
   });
 });
+
+
+describe('Custom QueryClient', () => {
+  let queryClient: QueryClient;
+  let customQueryClientInstance: _QueryClient;
+
+  it('should use custom query client', fakeAsync(() => {
+    customQueryClientInstance = new _QueryClient();
+    TestBed.configureTestingModule({
+      providers: [provideQueryClient(customQueryClientInstance)],
+    });
+    TestBed.runInInjectionContext(() => {
+      queryClient = injectQueryClient();
+    });
+
+    expect(queryClient).toBe(customQueryClientInstance);
+  }));
+
+  it('should use custom query client provided from function', fakeAsync(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideQueryClient(() => {
+          customQueryClientInstance = new _QueryClient();
+          return customQueryClientInstance;
+        }),
+      ],
+    });
+    TestBed.runInInjectionContext(() => {
+      queryClient = injectQueryClient();
+    });
+
+    expect(queryClient).toBe(customQueryClientInstance);
+  }));
+
+});
+


### PR DESCRIPTION
…via function

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/query/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

provideQueryClient() function accepts only QueryClient instance, so it is not possible to pass a custom instance being in injection context. 
Accepting a function as argument allows to be in injection context and pass object which was e.g. provided via DI in different place.

Issue Number: 204

## What is the new behavior?

provideQueryClient() function accepts also a function as argument 

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
